### PR TITLE
Only catch RestClient exceptions

### DIFF
--- a/lib/unirest.rb
+++ b/lib/unirest.rb
@@ -71,7 +71,7 @@ module Unirest
         end
      rescue RestClient::RequestTimeout
       raise 'Request Timeout'
-     rescue => e
+     rescue RestClient::Exception => e
          http_response = e.response
      end
 

--- a/test/unirest_test.rb
+++ b/test/unirest_test.rb
@@ -146,6 +146,15 @@ module Unirest
       assert response.code == 200
     end
 
+    should "Throw underlying error" do
+
+      begin
+        Unirest.get("http://bad.domain.test")
+      rescue => e
+        assert ! e.is_a?(NoMethodError)
+      end
+    end
+
     should "Default Headers" do
 
       Unirest.default_header('Hello','test')


### PR DESCRIPTION
This should resolve the issue where underlying system exceptions
were being suppressed accidentally.
