### PR TITLE
Updates rest-client gem version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,48 @@
+PATH
+  remote: .
+  specs:
+    unirest (1.1.2)
+      addressable (~> 2.3.5)
+      json (~> 1.8.1)
+      rest-client (~> 1.7)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (4.2.0)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    addressable (2.3.6)
+    i18n (0.7.0)
+    json (1.8.2)
+    mime-types (2.4.3)
+    minitest (5.5.1)
+    netrc (0.10.2)
+    power_assert (0.2.2)
+    rake (10.4.2)
+    rest-client (1.7.2)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
+    shoulda (3.5.0)
+      shoulda-context (~> 1.0, >= 1.0.1)
+      shoulda-matchers (>= 1.4.1, < 3.0)
+    shoulda-context (1.2.1)
+    shoulda-matchers (2.7.0)
+      activesupport (>= 3.0.0)
+    test-unit (3.0.9)
+      power_assert
+    thread_safe (0.3.4)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rake
+  shoulda (~> 3.5.0)
+  test-unit
+  unirest!

--- a/unirest.gemspec
+++ b/unirest.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/Mashape/unirest-ruby'
   s.license     = 'MIT'
 
-	s.add_dependency('rest-client', '~> 1.6.7')
+	s.add_dependency('rest-client', '~> 1.7')
 	s.add_dependency('json', '~> 1.8.1')
 	s.add_dependency('addressable', '~> 2.3.5')
 


### PR DESCRIPTION
This is the last version of rest-client gem at the moment.

I want to be able to use airbone gem for testing my API but there's a conflict between gems which this PR intends to fix.

```shell
Bundler could not find compatible versions for gem "rest-client":
  In Gemfile:
    airborne (>= 0) ruby depends on
      rest-client (>= 1.7.2, ~> 1.7) ruby

    unbabel (>= 0) ruby depends on
      unirest (>= 1.1.2, ~> 1.1) ruby depends on
        rest-client (1.6.7)
```

Thank you,
David Silva