### PR TITLE
relax rest-client version dependency

### DIFF
--- a/unirest.gemspec
+++ b/unirest.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/Mashape/unirest-ruby'
   s.license     = 'MIT'
 
-	s.add_dependency('rest-client', '~> 1.6.7')
+	s.add_dependency('rest-client', '~> 1.6')
 	s.add_dependency('json', '~> 1.8.1')
 	s.add_dependency('addressable', '~> 2.3.5')
 


### PR DESCRIPTION
I'm using unirest as a dependency of @urbanairship and this strict dependency on rest-client is causing some version resolution issues for me.  Is there a reason you need to pin on rest-client v1.6?  I'm trying to use rest-client v1.8.