### PR TITLE
Updates 'rest-client' insecure version

### DIFF
--- a/unirest.gemspec
+++ b/unirest.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/Mashape/unirest-ruby'
   s.license     = 'MIT'
 
-	s.add_dependency('rest-client', '~> 1.6.7')
+	s.add_dependency('rest-client', '~> 1.8.0')
 	s.add_dependency('json', '~> 1.8.1')
 	s.add_dependency('addressable', '~> 2.3.5')
 


### PR DESCRIPTION
Just updated the 'rest-client' version from 1.6.7 to 1.8.0 to fix a known security problem, as explained in this issue => https://github.com/Mashape/unirest-ruby/issues/24